### PR TITLE
Fix multipart boundary over-capture for unquoted boundary with trailing params (#82)

### DIFF
--- a/jb-email-synchro/classes/rawemailmessage.class.inc.php
+++ b/jb-email-synchro/classes/rawemailmessage.class.inc.php
@@ -449,7 +449,7 @@ class RawEmailMessage {
 		$aParsedParts = array();
 		$sContentType = isset($aHeaders['content-type']) ? $aHeaders['content-type'] : '';
 
-		if(($sContentType != '') && preg_match('/multipart(.*);.*?boundary="?([^"]+)"?/i', $sContentType, $aMatches)) {
+		if(($sContentType != '') && preg_match('/multipart(.*);.*?boundary="?([^";]+)"?/i', $sContentType, $aMatches)) {
 			$sBoundary = $aMatches[2];
 			if(empty($sBoundary)) {
 				// hmm, malformed message ??


### PR DESCRIPTION
Fixes #82.

## Why
`RawEmailMessage::ExtractParts()` extracted the multipart boundary with:

```php
preg_match('/multipart(.*);.*?boundary="?([^"]+)"?/i', $sContentType, $aMatches)
```

The capture group `([^"]+)` only excludes the double-quote. When the `boundary` parameter is **unquoted** and followed by further `Content-Type` parameters (e.g. `multipart/mixed; boundary=abc123; charset=UTF-8`), there is no closing `"` to stop at, so the group greedily swallows the trailing `; charset=UTF-8`. The resulting `$sBoundary` is wrong, and `SplitIntoParts()` then fails to split the message — the text body and attachments are mis-parsed.

## What
Exclude `;` from the boundary capture group so it also stops at the next parameter delimiter for unquoted boundaries:

```diff
-  preg_match('/multipart(.*);.*?boundary="?([^"]+)"?/i', $sContentType, $aMatches)
+  preg_match('/multipart(.*);.*?boundary="?([^";]+)"?/i', $sContentType, $aMatches)
```

This is exactly the change suggested in #82. Per RFC 2046 §5.1.1, `;` is not a legal boundary character (it is absent from `bcharsnospace`), so RFC-compliant boundaries — quoted or unquoted — are unaffected.

## Where
`jb-email-synchro/classes/rawemailmessage.class.inc.php` (line 452).

## Verification
The repo has no test harness, so I reproduced with a standalone PHP 8.2 script that builds raw messages and checks `GetTextBody()` and `GetAttachments()`. Regression matrix (6 cases), run against the file **before** and **after** the change:

**Before** — 2 fail:
```
[FAIL] unquoted+trailing (BUG case)       att=0  body="Hello body text\n--B\nContent-Type: te..."
[PASS] quoted (standard)                  att=1(att.txt)
[PASS] unquoted simple (no trailing)      att=1(att.txt)
[PASS] quoted + trailing param            att=1(att.txt)
[FAIL] multipart/alternative unquoted+tr  att=0
[PASS] boundary before other params       att=1(att.txt)
```

**After** — all pass:
```
[PASS] unquoted+trailing (BUG case)       att=1(att.txt)  body="Hello body text"
[PASS] quoted (standard)                  att=1(att.txt)
[PASS] unquoted simple (no trailing)      att=1(att.txt)
[PASS] quoted + trailing param            att=1(att.txt)
[PASS] multipart/alternative unquoted+tr  att=1(att.txt)
[PASS] boundary before other params       att=1(att.txt)
```

Reproduction script (drop next to the class, run `php repro.php <path-to-rawemailmessage.class.inc.php>`):

```php
<?php
require $argv[1];
function mk($ct){ return implode("\r\n", array(
  'From: s@example.com','To: d@example.com','Subject: t','Content-Type: '.$ct,'',
  '--B','Content-Type: text/plain; charset=UTF-8','','Hello body text',
  '--B','Content-Type: text/plain; name="att.txt"','Content-Disposition: attachment; filename="att.txt"','','attachment payload',
  '--B--','')); }
$cases = array(
  'unquoted+trailing (BUG case)' => 'multipart/mixed; boundary=B; charset=UTF-8',
  'quoted (standard)'            => 'multipart/mixed; boundary="B"',
  'unquoted simple'             => 'multipart/mixed; boundary=B',
  'quoted + trailing param'     => 'multipart/mixed; boundary="B"; charset=UTF-8',
  'alternative unquoted+tr'     => 'multipart/alternative; boundary=B; charset=UTF-8',
  'boundary before other params'=> 'multipart/mixed; charset=UTF-8; boundary=B',
);
$fail=0;
foreach($cases as $name=>$ct){
  $o=new RawEmailMessage(mk($ct)); $body=trim((string)$o->GetTextBody());
  $att=$o->GetAttachments(); $names=array(); foreach($att as $a){$names[]=$a['filename'];}
  $ok=($body==='Hello body text' && count($att)===1 && in_array('att.txt',$names,true));
  if(!$ok)$fail++; printf("[%s] %s att=%d\n", $ok?'PASS':'FAIL', $name, count($att));
}
exit($fail?1:0);
```

`php -l` passes on the changed file. Commit is DCO signed-off.
