### PR TITLE
Enhancement: Review MailInboxStandard datamodel presentation (details)

### DIFF
--- a/jb-itop-standard-email-synchro/datamodel.jb-itop-standard-email-synchro.xml
+++ b/jb-itop-standard-email-synchro/datamodel.jb-itop-standard-email-synchro.xml
@@ -699,20 +699,20 @@ EOF
 								<item id="behavior">
 									<rank>10</rank>
 								</item>
-								<item id="target_folder">
-									<rank>11</rank>
+								<item id="title_pattern">
+									<rank>20</rank>
 								</item>
 								<item id="email_storage">
-									<rank>20</rank>
+									<rank>30</rank>
+								</item>
+								<item id="target_folder">
+									<rank>40</rank>
 								</item>
 								<item id="target_class">
 									<rank>50</rank>
 								</item>
 								<item id="ticket_default_values">
 									<rank>60</rank>
-								</item>
-								<item id="title_pattern">
-									<rank>70</rank>
 								</item>
 								<item id="stimuli">
 									<rank>80</rank>

--- a/jb-itop-standard-email-synchro/dictionaries/en.dict.jb-itop-standard-email-synchro.php
+++ b/jb-itop-standard-email-synchro/dictionaries/en.dict.jb-itop-standard-email-synchro.php
@@ -26,7 +26,7 @@ Dict::Add('EN US', 'English', 'English', array(
 	// Dictionary entries go here
 	'Class:MailInboxStandard' => 'IMAP Mail Inbox',
 	'Class:MailInboxStandard+' => 'Source of incoming e-mails',
-	'Class:MailInboxStandard/Attribute:behavior' => 'Behavior',
+	'Class:MailInboxStandard/Attribute:behavior' => 'Behavior when processing an e-mail',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Create new Tickets',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Update existing Tickets',
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Create or Update Tickets',
@@ -54,7 +54,7 @@ Dict::Add('EN US', 'English', 'English', array(
 	'Class:MailInboxStandard/Attribute:debug_trace+' => '',
 	'Class:MailInboxStandard/Attribute:target_folder' => 'Target folder',
 	'Class:MailInboxStandard/Attribute:target_folder+' => 'The e-mail will be moved (IMAP protocol) to this target folder after being processed. Mind to update the setting for "After processing the e-mail" to "Move to another folder".',
-	
+
 	'Class:MailInboxStandard/Attribute:ticket_default_values' => 'Default values for new Ticket',
 	'Class:MailInboxStandard/Attribute:ticket_default_title' => 'Default title (if subject is empty)',
 	'Class:MailInboxStandard/Attribute:title_pattern+' => 'Pattern to match in the subject',
@@ -75,7 +75,7 @@ Dict::Add('EN US', 'English', 'English', array(
 	   
 	'Class:MailInboxStandard/Attribute:debug_log' => 'Debug Log',
 	
-	'Class:MailInboxStandard/Attribute:error_behavior' => 'Behavior',
+	'Class:MailInboxStandard/Attribute:error_behavior' => 'Behavior when error occurs during processing',
 	'Class:MailInboxStandard/Attribute:error_behavior/Value:delete' => 'Delete the message from the mailbox',
 	'Class:MailInboxStandard/Attribute:error_behavior/Value:mark_as_error' => 'Mark as Error', 
 	'Class:MailInboxStandard/Attribute:notify_errors_to' => 'Forward e-mails (in error) To Address',
@@ -270,9 +270,12 @@ Dict::Add('EN US', 'English', 'English', array(
 	// Headers
 	'MailInbox:Server' => 'Mailbox Configuration',
 	'MailInbox:Behavior' => 'Behavior on Incoming e-mails',
-	'MailInbox:Errors' => 'E-mails in error', 
-	'MailInbox:Settings' => 'Settings', 
-	
+	'MailInbox:Errors' => 'E-mails in error',
+	'MailInbox:Settings' => 'Settings',
+
+	// Validation messages
+	'MailInbox:Error:TargetFolderRequired' => 'The target folder must be specified for an active mailbox.',
+
 	// Steps
 	'MailInbox:StepAttachmentCriteria' => 'Embedded e-mail images',
 	'MailInbox:PolicyMailSize' => 'Mail Size',

--- a/jb-itop-standard-email-synchro/dictionaries/fr.dict.jb-itop-standard-email-synchro.php
+++ b/jb-itop-standard-email-synchro/dictionaries/fr.dict.jb-itop-standard-email-synchro.php
@@ -26,7 +26,7 @@ Dict::Add('FR FR', 'French', 'Français', array(
 	// Dictionary entries go here
 	'Class:MailInboxStandard' => 'Boîte Mail Standard',
 	'Class:MailInboxStandard+' => 'Source d\'eMails',
-	'Class:MailInboxStandard/Attribute:behavior' => 'Comportement',
+	'Class:MailInboxStandard/Attribute:behavior' => 'Comportement lors du traitement d\'un e-mail',
 	'Class:MailInboxStandard/Attribute:behavior/Value:create_only' => 'Créer des Tickets',
 	'Class:MailInboxStandard/Attribute:behavior/Value:update_only' => 'Mettre à jour des Tickets existants',
 	'Class:MailInboxStandard/Attribute:behavior/Value:both' => 'Créer ou mettre à jour des Tickets',
@@ -74,7 +74,7 @@ Dict::Add('FR FR', 'French', 'Français', array(
 	   
 	'Class:MailInboxStandard/Attribute:debug_log' => 'Traces de Debug',
 	
-	'Class:MailInboxStandard/Attribute:error_behavior' => 'Comportement en cas d\'erreur',
+	'Class:MailInboxStandard/Attribute:error_behavior' => 'Comportement en cas d\'erreur lors du traitement',
 	'Class:MailInboxStandard/Attribute:error_behavior/Value:delete' => 'Supprimer l\'eMail de la boîte mail',
 	'Class:MailInboxStandard/Attribute:error_behavior/Value:mark_as_error' => 'Garder l\'eMail dans la boîte mail',
 	'Class:MailInboxStandard/Attribute:notify_errors_to' => 'Faire suivre l\'eMail à',
@@ -249,8 +249,11 @@ Dict::Add('FR FR', 'French', 'Français', array(
 	'MailInbox:Server' => 'Configuration de la boîte mail',
 	'MailInbox:Behavior' => 'Comportement pour les nouveaux emails',
 	'MailInbox:Errors' => 'E-mails en erreur',
-	'MailInbox:Settings' => 'Configuration', 
-	
+	'MailInbox:Settings' => 'Configuration',
+
+	// Messages de validation
+	'MailInbox:Error:TargetFolderRequired' => 'Le dossier cible doit être renseigné pour une boîte mail active.',
+
 	// Steps
 	'MailInbox:StepAttachmentCriteria' => 'Pièce jointe - criteria',
 	'MailInbox:PolicyMailSize' => 'Taille de l\'email',

--- a/jb-itop-standard-email-synchro/src/JeffreyBostoenExtensions/MailToTicket/EventListener.php
+++ b/jb-itop-standard-email-synchro/src/JeffreyBostoenExtensions/MailToTicket/EventListener.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @copyright   Copyright (c) 2020-2026 Jeffrey Bostoen
+ * @license     See license.md
+ * @version     3.2.260711
+ */
+
+
+namespace JeffreyBostoenExtensions\MailToTicket;
+
+// iTop internals.
+use Dict;
+
+// iTop events.
+use Combodo\iTop\Service\Events\EventData;
+use Combodo\iTop\Service\Events\EventService;
+
+// iTop classes.
+use MailInboxStandard;
+
+/**
+ * Class EventListener.
+ * Registers event listeners for this module.
+ */
+abstract class EventListener {
+
+	/**
+	 * Registers the event listeners of this module.
+	 *
+	 * @return void
+	 */
+	public static function RegisterListeners() : void {
+
+		EventService::RegisterListener(
+			\EVENT_DB_CHECK_TO_WRITE,
+			[static::class, 'OnMailInboxStandardTargetFolderCheckToWrite'],
+			'MailInboxStandard'
+		);
+
+	}
+
+	/**
+	 * Validates that the target folder is specified for an active mailbox.
+	 *
+	 * @param EventData $oEventData Event data. Contains the object ('object') being checked.
+	 *
+	 * @return void
+	 */
+	public static function OnMailInboxStandardTargetFolderCheckToWrite(EventData $oEventData) : void {
+
+		/** @var MailInboxStandard $oMailInbox */
+		$oMailInbox = $oEventData->Get('object');
+
+		if($oMailInbox->Get('active') === 'yes' && trim($oMailInbox->Get('target_folder')) === '') {
+
+			$oMailInbox->AddCheckIssue(Dict::Format('MailInbox:Error:TargetFolderRequired'));
+
+		}
+
+	}
+
+}
+
+EventListener::RegisterListeners();


### PR DESCRIPTION
## What

- Clarifies the ambiguous "Behavior" labels: `behavior` becomes "Behavior when processing an e-mail" and `error_behavior` becomes "Behavior when error occurs during processing".
- Adds a `DoCheckToWrite` validation requiring `target_folder` to be set for an active mailbox.

## Why

The `MailInboxStandard` details form reused the same "Behavior" label for two different settings, which is confusing when both appear as tab/section labels. An active mailbox with no target folder configured was previously allowed to save without any warning.

The description/case log attribute code configurability originally scoped here has been moved to #63, since it's the mechanism that feature actually needs rather than a presentation concern.

Closes #80