### PR TITLE
Enhancement: Add case log entry upon creation

### DIFF
--- a/jb-itop-standard-email-synchro/datamodel.jb-itop-standard-email-synchro.xml
+++ b/jb-itop-standard-email-synchro/datamodel.jb-itop-standard-email-synchro.xml
@@ -54,6 +54,16 @@
 					<default_value>UserRequest</default_value>
 					<is_null_allowed>false</is_null_allowed>
 				</field>
+				<field id="attcode_description" xsi:type="AttributeString">
+					<sql>attcode_description</sql>
+					<default_value>description</default_value>
+					<is_null_allowed>true</is_null_allowed>
+				</field>
+				<field id="attcode_caselog" xsi:type="AttributeString">
+					<sql>attcode_caselog</sql>
+					<default_value/>
+					<is_null_allowed>true</is_null_allowed>
+				</field>
 				<field id="ticket_default_values" xsi:type="AttributeText">
 					<sql>ticket_default_values</sql>
 					<default_value>
@@ -710,6 +720,12 @@ EOF
 								</item>
 								<item id="target_class">
 									<rank>50</rank>
+								</item>
+								<item id="attcode_description">
+									<rank>55</rank>
+								</item>
+								<item id="attcode_caselog">
+									<rank>58</rank>
 								</item>
 								<item id="ticket_default_values">
 									<rank>60</rank>

--- a/jb-itop-standard-email-synchro/dictionaries/en.dict.jb-itop-standard-email-synchro.php
+++ b/jb-itop-standard-email-synchro/dictionaries/en.dict.jb-itop-standard-email-synchro.php
@@ -55,6 +55,11 @@ Dict::Add('EN US', 'English', 'English', array(
 	'Class:MailInboxStandard/Attribute:target_folder' => 'Target folder',
 	'Class:MailInboxStandard/Attribute:target_folder+' => 'The e-mail will be moved (IMAP protocol) to this target folder after being processed. Mind to update the setting for "After processing the e-mail" to "Move to another folder".',
 
+	'Class:MailInboxStandard/Attribute:attcode_description' => 'Description attribute',
+	'Class:MailInboxStandard/Attribute:attcode_description+' => 'Attribute code of the target class that should receive the initial ticket description. Defaults to "description" when left empty.',
+	'Class:MailInboxStandard/Attribute:attcode_caselog' => 'Case log attribute',
+	'Class:MailInboxStandard/Attribute:attcode_caselog+' => 'Attribute code of the target class (case log) that should receive new entries when the ticket is created and/or updated. Defaults to "public_log" when left empty or invalid.',
+
 	'Class:MailInboxStandard/Attribute:ticket_default_values' => 'Default values for new Ticket',
 	'Class:MailInboxStandard/Attribute:ticket_default_title' => 'Default title (if subject is empty)',
 	'Class:MailInboxStandard/Attribute:title_pattern+' => 'Pattern to match in the subject',
@@ -275,6 +280,8 @@ Dict::Add('EN US', 'English', 'English', array(
 
 	// Validation messages
 	'MailInbox:Error:TargetFolderRequired' => 'The target folder must be specified for an active mailbox.',
+	'MailInbox:Error:CaseLogAttCodeRequired' => 'The case log attribute code must be a valid attribute of the target class \'%1$s\'.',
+	'MailInbox:Error:DescriptionOrCaseLogAttCodeRequired' => 'Either the description attribute code or the case log attribute code must be a valid attribute of the target class \'%1$s\'.',
 
 	// Steps
 	'MailInbox:StepAttachmentCriteria' => 'Embedded e-mail images',

--- a/jb-itop-standard-email-synchro/dictionaries/fr.dict.jb-itop-standard-email-synchro.php
+++ b/jb-itop-standard-email-synchro/dictionaries/fr.dict.jb-itop-standard-email-synchro.php
@@ -55,6 +55,11 @@ Dict::Add('FR FR', 'French', 'Français', array(
 	'Class:MailInboxStandard/Attribute:target_folder' => 'Target folder',
 	'Class:MailInboxStandard/Attribute:target_folder+' => 'Use to move an email with the IMAP protocol',
 
+	'Class:MailInboxStandard/Attribute:attcode_description' => 'Attribut de description',
+	'Class:MailInboxStandard/Attribute:attcode_description+' => 'Code de l\'attribut de la classe cible qui doit recevoir la description initiale du ticket. Par défaut : "description" si laissé vide.',
+	'Class:MailInboxStandard/Attribute:attcode_caselog' => 'Attribut du journal (case log)',
+	'Class:MailInboxStandard/Attribute:attcode_caselog+' => 'Code de l\'attribut de la classe cible (journal des échanges) qui doit recevoir les nouvelles entrées lors de la création et/ou de la mise à jour du ticket. Par défaut : "public_log" si laissé vide ou invalide.',
+
 	'Class:MailInboxStandard/Attribute:ticket_default_values' => 'Valeurs par défaut du Ticket',
 	'Class:MailInboxStandard/Attribute:ticket_default_title' => 'Titre par défaut (en cas de sujet vide)',
 	'Class:MailInboxStandard/Attribute:title_pattern+' => 'Expression régulière à rechercher dans l\'objet de l\'eMail',
@@ -253,6 +258,8 @@ Dict::Add('FR FR', 'French', 'Français', array(
 
 	// Messages de validation
 	'MailInbox:Error:TargetFolderRequired' => 'Le dossier cible doit être renseigné pour une boîte mail active.',
+	'MailInbox:Error:CaseLogAttCodeRequired' => 'Le code de l\'attribut du journal des échanges (case log) doit être un attribut valide de la classe cible \'%1$s\'.',
+	'MailInbox:Error:DescriptionOrCaseLogAttCodeRequired' => 'Le code de l\'attribut de la description ou celui du journal des échanges (case log) doit être un attribut valide de la classe cible \'%1$s\'.',
 
 	// Steps
 	'MailInbox:StepAttachmentCriteria' => 'Pièce jointe - criteria',

--- a/jb-itop-standard-email-synchro/module.jb-itop-standard-email-synchro.php
+++ b/jb-itop-standard-email-synchro/module.jb-itop-standard-email-synchro.php
@@ -29,6 +29,7 @@ SetupWebPage::AddModule(
 		//
 		'datamodel' => array(
 			'model.jb-itop-standard-email-synchro.php',
+			'src/JeffreyBostoenExtensions/MailToTicket/EventListener.php',
 			// Core processing.
 			'src/JeffreyBostoenExtensions/MailToTicket/Steps/Base.php',
 			'src/JeffreyBostoenExtensions/MailToTicket/Steps/Core/AttachmentCriteria.php',
@@ -77,7 +78,6 @@ SetupWebPage::AddModule(
 		'settings' => array(
 			// Module specific settings go here, if any
 			'inline_image_max_width' => 500, // Maximum width (in px) for displaying inline images
-			'ticket_log' => array('UserRequest' => 'public_log', 'Incident' => 'public_log'),
 		),
 	)
 );

--- a/jb-itop-standard-email-synchro/src/JeffreyBostoenExtensions/MailToTicket/EventListener.php
+++ b/jb-itop-standard-email-synchro/src/JeffreyBostoenExtensions/MailToTicket/EventListener.php
@@ -10,6 +10,7 @@ namespace JeffreyBostoenExtensions\MailToTicket;
 
 // iTop internals.
 use Dict;
+use MetaModel;
 
 // iTop events.
 use Combodo\iTop\Service\Events\EventData;
@@ -37,6 +38,12 @@ abstract class EventListener {
 			'MailInboxStandard'
 		);
 
+		EventService::RegisterListener(
+			\EVENT_DB_CHECK_TO_WRITE,
+			[static::class, 'OnMailInboxStandardAttCodesCheckToWrite'],
+			'MailInboxStandard'
+		);
+
 	}
 
 	/**
@@ -54,6 +61,51 @@ abstract class EventListener {
 		if($oMailInbox->Get('active') === 'yes' && trim($oMailInbox->Get('target_folder')) === '') {
 
 			$oMailInbox->AddCheckIssue(Dict::Format('MailInbox:Error:TargetFolderRequired'));
+
+		}
+
+	}
+
+	/**
+	 * Validates the description / case log attribute codes, according to the configured behavior.
+	 *
+	 * @param EventData $oEventData Event data. Contains the object ('object') being checked.
+	 *
+	 * @return void
+	 */
+	public static function OnMailInboxStandardAttCodesCheckToWrite(EventData $oEventData) : void {
+
+		/** @var MailInboxStandard $oMailInbox */
+		$oMailInbox = $oEventData->Get('object');
+		$sTargetClass = $oMailInbox->Get('target_class');
+
+		if(!MetaModel::IsValidClass($sTargetClass)) {
+			return;
+		}
+
+		$sBehavior = $oMailInbox->Get('behavior');
+		$sAttCodeDescription = trim($oMailInbox->Get('attcode_description'));
+		$sAttCodeCaseLog = trim($oMailInbox->Get('attcode_caselog'));
+
+		if($sBehavior === 'both' || $sBehavior === 'update_only') {
+
+			if($sAttCodeCaseLog === '' || !MetaModel::IsValidAttCode($sTargetClass, $sAttCodeCaseLog)) {
+
+				$oMailInbox->AddCheckIssue(Dict::Format('MailInbox:Error:CaseLogAttCodeRequired', $sTargetClass));
+
+			}
+
+		}
+		elseif($sBehavior === 'create_only') {
+
+			$bValidDescription = ($sAttCodeDescription !== '' && MetaModel::IsValidAttCode($sTargetClass, $sAttCodeDescription));
+			$bValidCaseLog = ($sAttCodeCaseLog !== '' && MetaModel::IsValidAttCode($sTargetClass, $sAttCodeCaseLog));
+
+			if(!$bValidDescription && !$bValidCaseLog) {
+
+				$oMailInbox->AddCheckIssue(Dict::Format('MailInbox:Error:DescriptionOrCaseLogAttCodeRequired', $sTargetClass));
+
+			}
 
 		}
 

--- a/jb-itop-standard-email-synchro/src/JeffreyBostoenExtensions/MailToTicket/Steps/Core/CreateOrUpdateTicket.php
+++ b/jb-itop-standard-email-synchro/src/JeffreyBostoenExtensions/MailToTicket/Steps/Core/CreateOrUpdateTicket.php
@@ -227,7 +227,11 @@ abstract class CreateOrUpdateTicket extends Base {
 		static::AddAttachments(true);
 		
 		// Seems to be for backward compatibility / plain text.
-		$oTicketDescriptionAttDef = MetaModel::GetAttributeDef($sTargetClass, 'description');
+		$sDescriptionAttCode = trim($oMailBox->Get('attcode_description'));
+		if($sDescriptionAttCode === '' || !MetaModel::IsValidAttCode($sTargetClass, $sDescriptionAttCode)) {
+			$sDescriptionAttCode = 'description';
+		}
+		$oTicketDescriptionAttDef = MetaModel::GetAttributeDef($sTargetClass, $sDescriptionAttCode);
 		$bForPlainText = true; // Target format is plain text (by default)
 		if ($oTicketDescriptionAttDef instanceof AttributeHTML) {
 			// Target format is HTML
@@ -260,8 +264,11 @@ abstract class CreateOrUpdateTicket extends Base {
 		}
 
 		// Keep some room just in case... (in case of what?)
-		$oTicket->Set('description', static::FitTextIn($sTicketDescription, $iDescriptionMaxSize));
-		
+		$oTicket->Set($sDescriptionAttCode, static::FitTextIn($sTicketDescription, $iDescriptionMaxSize));
+
+		// Harmonize with UpdateTicketFromEmail(): also add the original message as a first case log entry.
+		static::AddInitialCaseLogEntry($oTicket, $oCaller);
+
 		// Default values.
 		$sDefaultValues = $oMailBox->Get('ticket_default_values');
 		$aDefaults = preg_split(static::NEWLINE_REGEX, $sDefaultValues);
@@ -390,16 +397,8 @@ abstract class CreateOrUpdateTicket extends Base {
 		}
 					
 		// Determine which field to update
-		$sAttCode = 'public_log';
-		$aAttCodes = MetaModel::GetModuleSetting('jb-itop-standard-email-synchro', 'ticket_log', [
-			'UserRequest' => 'public_log', 
-			'Incident' => 'public_log'
-		]);
-		
-		if(array_key_exists(get_class($oTicket), $aAttCodes) == true) {
-			$sAttCode = $aAttCodes[get_class($oTicket)];
-		}
-		
+		$sAttCode = static::GetCaseLogAttCode(get_class($oTicket));
+
 		$oCaseLog = $oTicket->Get($sAttCode);
 		$oAttributeValue = new ormCustomCaseLog();
 		$oAttributeValue->AddLogEntriesFromCaseLog($oCaseLog);
@@ -801,6 +800,74 @@ abstract class CreateOrUpdateTicket extends Base {
 		
 	}
 	
+	/**
+	 * Returns the case log attribute code (e.g. 'public_log') that should be updated for a given Ticket class,
+	 * based on the mailbox's 'attcode_caselog' setting.
+	 *
+	 * @param String $sTargetClass Ticket (sub)class
+	 *
+	 * @return String Attribute code
+	 */
+	public static function GetCaseLogAttCode(string $sTargetClass) : string {
+
+		$oMailBox = ProcessingHelper::GetMailBox();
+		$sAttCode = trim($oMailBox->Get('attcode_caselog'));
+
+		if($sAttCode === '' || MetaModel::IsValidAttCode($sTargetClass, $sAttCode) == false) {
+			$sAttCode = 'public_log';
+		}
+
+		return $sAttCode;
+
+	}
+
+	/**
+	 * Adds an initial case log entry (e.g. 'public_log') to a newly created Ticket, based on the email body.
+	 *
+	 * @details Harmonizes the case log with the way Ticket updates (replies) are processed via UpdateTicketFromEmail():
+	 * both the ticket's description and its case log will contain the original message.
+	 *
+	 * @param Ticket $oTicket Newly created Ticket (not saved yet)
+	 * @param Person|null $oCaller Caller detected from the incoming email (if any)
+	 *
+	 * @return void
+	 */
+	public static function AddInitialCaseLogEntry(Ticket $oTicket, ?Person $oCaller) : void {
+
+		$sTargetClass = get_class($oTicket);
+		$sAttCode = static::GetCaseLogAttCode($sTargetClass);
+
+		if(MetaModel::IsValidAttCode($sTargetClass, $sAttCode) == false) {
+			return;
+		}
+
+		$oEmail = ProcessingHelper::GetMail();
+
+		// Fallback to e-mail address if name is unknown.
+		$sCallerName = $oEmail->sCallerName;
+		$iCallerUserId = null;
+		if($oCaller === null) {
+			$sCallerName = $oEmail->sCallerEmail;
+		}
+		else {
+			$sCallerName = $oCaller->GetName(); // Derive name from Person
+			// Only first user will be matched. Multiple accounts could theoretically be linked to 1 Person.
+			$oUser = UserRights::GetUserFromPerson($oCaller, false);
+			if($oUser !== null) {
+				$iCallerUserId = $oUser->GetKey();
+			}
+		}
+
+		$sCaseLogEntry = static::BuildCaseLogEntry();
+
+		$oAttributeValue = new ormCustomCaseLog();
+		$oAttributeValue->AddLogEntry($sCaseLogEntry, $sCallerName, $iCallerUserId, '');
+		$oAttributeValue = $oAttributeValue->ToSortedCaseLog(false);
+
+		$oTicket->Set($sAttCode, $oAttributeValue);
+
+	}
+
 	/**
 	 * Attaches the original raw e-mail (.eml) to the current Ticket.
 	 *


### PR DESCRIPTION
## What

- Adds an initial case log entry to newly created Tickets, harmonizing with `UpdateTicketFromEmail()`, which already adds the original message as a case log entry when a ticket is updated by a reply. Both the ticket's description and its case log now contain the original message on creation.
- Adds per-mailbox `attcode_description` / `attcode_caselog` attributes (with a `DoCheckToWrite` validation) so the description and case log target attributes can be configured from the datamodel/UI instead of being hardcoded (`description`) or driven by the `ticket_log` module setting.

## Why

To harmonize the public log, a first case log entry should be added upon ticket creation, not just the description field. Doing so requires knowing which case log attribute to write to, which the mailbox previously could only express through the `ticket_log` module setting (not configurable per mailbox from the UI, and not applicable to the description attribute at all).

Closes #63